### PR TITLE
Update wcp-init.js

### DIFF
--- a/website/static/scripts/wcp-init.js
+++ b/website/static/scripts/wcp-init.js
@@ -1,22 +1,33 @@
-// Using Client Modules
-// https://docusaurus.io/docs/advanced/client#client-modules
-// For this to work, we need 
-// <div id="cookie-banner"></div> to exist in body of page
-// TODO: Swizzle docusaurus to add the id in
-
+import React, { useEffect, useState } from 'react';
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 
-function onConsentChanged(categoryPreferences) {
+function CookieBanner() {
+  const [siteConsent, setSiteConsent] = useState(null);
+
+  function onConsentChanged(categoryPreferences) {
     console.log("onConsentChanged", categoryPreferences);        
+  }
+
+  useEffect(() => {
+    if (ExecutionEnvironment.canUseDOM) {
+      // As soon as the site loads in the browser, register a global event listener
+      window.WcpConsent && WcpConsent.init("en-US", "cookie-banner", function (err, _siteConsent) {
+          if (!err) {
+              setSiteConsent(_siteConsent);  //set siteConsent to the current consent          
+          } else {
+              console.log("Error initializing WcpConsent: "+ err);
+          }
+      }, onConsentChanged, WcpConsent.themes.light);
+    }
+  }, []);
+
+  return (
+    <div id="cookie-banner">
+      <p>This site uses cookies. By continuing to browse the site, you are agreeing to our use of cookies.</p>
+      <button onClick={() => siteConsent?.updateConsent(true)}>Accept</button>
+      <button onClick={() => siteConsent?.updateConsent(false)}>Decline</button>
+    </div>
+  );
 }
 
-if (ExecutionEnvironment.canUseDOM) {
-  // As soon as the site loads in the browser, register a global event listener
-    window.WcpConsent && WcpConsent.init("en-US", "cookie-banner", function (err, _siteConsent) {
-        if (!err) {
-            siteConsent = _siteConsent;  //siteConsent is used to get the current consent          
-        } else {
-            console.log("Error initializing WcpConsent: "+ err);
-        }
-    }, onConsentChanged, WcpConsent.themes.light);
-}
+export default CookieBanner;


### PR DESCRIPTION
This version adds a functional component CookieBanner that displays a banner with a message and two buttons, one for accepting cookies and one for declining cookies. It also uses useState and useEffect hooks to manage the state of the site's consent and to register a global event listener as soon as the site loads in the browser. Finally, it checks if ExecutionEnvironment.canUseDOM is true before executing the code, ensuring that the code is only run in the browser environment.